### PR TITLE
feat(linting): add curly rule to prettier config

### DIFF
--- a/packages/eslint-config/prettier.js
+++ b/packages/eslint-config/prettier.js
@@ -2,5 +2,7 @@ const path = require('path');
 
 module.exports = {
   extends: [path.resolve(require.resolve('eslint-config-prettier'))],
-  rules: {}
+  rules: {
+    curly: 'error'
+  }
 };


### PR DESCRIPTION
Third time is the charm 😄 

We need to overwrite this in the prettier configs since the prettier eslint configuration recommendation is to list the prettier config last, and the prettier config itself disables this rule due to problems with some of its configurations (which we're not using).

https://github.com/prettier/eslint-config-prettier#curly